### PR TITLE
skaia: correct milestone 2 description

### DIFF
--- a/js/layers/act0/skaia.js
+++ b/js/layers/act0/skaia.js
@@ -1021,7 +1021,7 @@ if (act == 0) addLayer("skaia", {
         2: {
             requirementDescription: "<p style='transform: scale(-1, -1)'><alternate>AGE OF GROWTH</alternate></p>4 Breath Essence & 4 Blood Essence",
             done() { return player.aspBreath.best.gte(4) && player.aspBlood.best.gte(4) },
-            effectDescription: "Keeps Hope Upgrades and Rage Milestones on Breath and Blood resets.",
+            effectDescription: "Keeps Hope Upgrades and Rage Challenges on Breath and Blood resets.",
         },
         3: {
             requirementDescription: "<p style='transform: scale(-1, -1)'><alternate>EVERYTHING IS ALMOST READY</alternate></p>6 Breath Essence & 6 Blood Essence",


### PR DESCRIPTION
this is the 4 Breath Essence 4 Blood Essence milestone.
It claims to keep Rage milestones.
But as we can see, it actually keeps the Rage challenge completions.
https://github.com/ducdat0507/prestreestuck/blob/506df0efdf2a0959c56466783f4a1f00f5d12a87/js/layers/act0/aspRage.js#L218-L220
Therefore the description should be corrected so that it correctly
describes the actual effect.