### PR TITLE
Back-fill extra meta-faucets for MORE FAUCETS upgrade.

### DIFF
--- a/js/layers/act0/metaMeta.js
+++ b/js/layers/act0/metaMeta.js
@@ -1704,6 +1704,10 @@ if (act == "0.2") addLayer("metaMeta", {
             unlocked() { 
                 return hasUpgrade("metaMeta", 113) 
             },
+            onPurchase() {
+                var squares = player["metaMeta"].buyables[91].sqrt().floor()
+                for (var a = 0; a < squares; a++) player[this.layer].metaFaucets.push(new Decimal(0))
+            },
         },
         101: {
             title: "<p style='transform: scale(-1, -1)'><alternate>REAL TIME</alternate>",


### PR DESCRIPTION
Purchasing the MORE FAUCETS upgrade is supposed to give you an extra
Meta-Faucet for each perfect square of Meta-Faucet Upgrades.
Unfortunately, this wasn't applied retroactively for previously
purchased Meta-Faucet Upgrades, and since at this point they're
auto-purchased it meant that players had to race to buy this upgrade
before the first Meta-Faucet Upgrade was bought. For some people this is
nearly impossible to do given how quickly the auto-purchasing happens,
and without the extra Meta-Faucets you're effectively stuck.